### PR TITLE
Remove duplicate restart during installer recipe

### DIFF
--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -12,7 +12,6 @@ template '/tmp/cwlogs.cfg' do
   variables ({
     :logfiles => node['cwlogs']['logfiles']
   })
-  notifies :restart, 'service[awslogs]'
 end
 
 directory '/opt/aws/cloudwatch' do


### PR DESCRIPTION
The /tmp/cwlogs.cfg template is input into the installer, not the real configuration file. It should not restart the service on change. This differs from the package recipe (which should notify).
The awslogs-agent-setup.py installer checks the input and already signals a restart is required.

With notifies :restart the daemon is restarted twice:
```
systemd[1]: Stopping LSB: Daemon for AWSLogs agent....
systemd[1]: Starting LSB: Daemon for AWSLogs agent....
systemd[1]: Started LSB: Daemon for AWSLogs agent..
systemd[1]: Stopping LSB: Daemon for AWSLogs agent....
systemd[1]: Stopped LSB: Daemon for AWSLogs agent..
systemd[1]: Starting LSB: Daemon for AWSLogs agent....
systemd[1]: Started LSB: Daemon for AWSLogs agent..
```