### PR TITLE
Ensure that the CloudWatch Logs installer does not try to reinstall if awslogs agent is already running

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ installer from AWS, then you can set the following attribute to `false`:
 ['cwlogs']['attempt_upgrade'] = false
 ```
 
+The CloudWatch agent no longer supports installs using Python 2.6. On systems with Python 2.6 set as default, you will need a newerv version of Python installed (2.7 minimum). You can then set the `default['cwlogs']['python_bin']` attribute to point to the >= 2.7 executable. 
+
+```ruby
+default['cwlogs']['python_bin'] = '/usr/bin/python2.7'
+```
+
 ## Example
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ The CloudWatch agent no longer supports installs using Python 2.6. On systems wi
 default['cwlogs']['python_bin'] = '/usr/bin/python2.7'
 ```
 
+Some systems require a root SSL certificate in order for python/pip to access remote https endpoints. For that purpose, you can specify a location to your system's root cert bundle using the `default['cwlogs']['ca_bundle']` attribute.
+
+```ruby
+default['cwlogs']['ca_bundle'] = '/path/to/my/bundle.pem'
+```
+
+You may want to provide your own installation file instead of using the default location from Amazon. To do so, update the `default['cwlogs']['installation_file_source']` attribute.
+
+```ruby
+default['cwlogs']['installation_file_source'] = 'https://your.internal.domain.org/path/to/installer.py'
+default['cwlogs']['installation_file_source'] = '/path/on/your/filesystem'
+```
+
 ## Example
 
 ```ruby

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,3 +2,6 @@ default['cwlogs']['region'] = 'us-east-1'
 default['cwlogs']['state_file_dir'] = '/var/awslogs/state'
 default['cwlogs']['state_file_name'] = 'agent-state'
 default['cwlogs']['attempt_upgrade'] = true
+default['cwlogs']['python_bin'] = ''
+default['cwlogs']['ca_bundle'] = ''
+default['cwlogs']['installation_file_source'] = 'https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py'

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -30,5 +30,5 @@ proxy_args = proxy_env.map { |k,v| "--#{k.gsub('_','-')} '#{v}'" }.join(' ')
 execute 'Install CloudWatch Logs agent' do
   command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r #{node['cwlogs']['region']} -c /tmp/cwlogs.cfg #{proxy_args}"
   guard_interpreter :bash
-  not_if { system 'pgrep -f awslogs >/dev/null' }
+  not_if 'pgrep -f awslogs >/dev/null'
 end

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -26,5 +26,5 @@ end
 
 execute 'Install CloudWatch Logs agent' do
   command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r #{node['cwlogs']['region']} -c /tmp/cwlogs.cfg"
-  not_if { system 'pgrep -f aws-logs-agent-setup' }
+  not_if { system 'pgrep -f awslogs' }
 end

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -1,8 +1,8 @@
 proxy_env = ENV.select { |k, v| %w(http_proxy https_proxy no_proxy).include?(k) && !v.empty? }
 proxy_args = proxy_env.map { |k,v| "--#{k.gsub('_','-')} '#{v}'" }.join(' ')
-python_bin_dir = node['cwlogs']['python_bin']
+python_bin = node['cwlogs']['python_bin']
 ca_bundle = node['cwlogs']['ca_bundle']
-python_flag = if !python_bin.nil? && ! python_bin.strip.empty?then "--python=#{python_bin}" else '' end 
+python_flag = if ! python_bin.nil? && ! python_bin.strip.empty?then "--python=#{python_bin}" else '' end 
 environment = {
   'REQUESTS_CA_BUNDLE' => if ! ca_bundle.nil? && ! ca_bundle.strip.empty? then ca_bundle else '' end 
 }

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -30,5 +30,5 @@ proxy_args = proxy_env.map { |k,v| "--#{k.gsub('_','-')} '#{v}'" }.join(' ')
 execute 'Install CloudWatch Logs agent' do
   command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r #{node['cwlogs']['region']} -c /tmp/cwlogs.cfg #{proxy_args}"
   guard_interpreter :bash
-  not_if 'pgrep -f awslogs-agent-setup >/dev/null'
+  not_if { system 'pgrep -f awslogs >/dev/null' }
 end

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -1,3 +1,12 @@
+proxy_env = ENV.select { |k, v| %w(http_proxy https_proxy no_proxy).include?(k) && !v.empty? }
+proxy_args = proxy_env.map { |k,v| "--#{k.gsub('_','-')} '#{v}'" }.join(' ')
+python_bin_dir = node['cwlogs']['python_bin']
+ca_bundle = node['cwlogs']['ca_bundle']
+python_flag = if !python_bin.nil? && ! python_bin.strip.empty?then "--python=#{python_bin}" else '' end 
+environment = {
+  'REQUESTS_CA_BUNDLE' => if ! ca_bundle.nil? && ! ca_bundle.strip.empty? then ca_bundle else '' end 
+}
+
 service 'awslogs' do
   # awslogs service is created, enabled, and started by the installer at the end of this recipe, but we need to declare
   # a chef resource for the template to notify
@@ -20,15 +29,16 @@ directory '/opt/aws/cloudwatch' do
 end
 
 remote_file '/opt/aws/cloudwatch/awslogs-agent-setup.py' do
-  source 'https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py'
+  source node['cwlogs']['installation_file_source']
   mode '0755'
   action node['cwlogs']['attempt_upgrade'] ? :create : :create_if_missing
+  notifies :run, 'execute[Install CloudWatch Logs agent]', :immediately
 end
 
-proxy_env = ENV.select { |k, v| %w(http_proxy https_proxy no_proxy).include?(k) && !v.empty? }
-proxy_args = proxy_env.map { |k,v| "--#{k.gsub('_','-')} '#{v}'" }.join(' ')
 execute 'Install CloudWatch Logs agent' do
-  command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r #{node['cwlogs']['region']} -c /tmp/cwlogs.cfg #{proxy_args}"
+  command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n #{python_flag} -r #{node['cwlogs']['region']} -c /tmp/cwlogs.cfg #{proxy_args}"
+  environment environment
   guard_interpreter :bash
-  not_if 'pgrep -f awslogs >/dev/null'
+  not_if 'pgrep -f awslogs-agent-setup >/dev/null'
+  action :nothing
 end


### PR DESCRIPTION
Fixes the reinstallation of the cloudwatch agent during each chef run