### PR TITLE
Agentdependencies patch

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ben@cloudar.be'
 license          'FreeBSD'
 description      'Installs and configures AWS CloudWatch Logs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.7'
+version          '0.1.0'
 
 %w{ ubuntu debian centos redhat fedora amazon}.each do |os|
   supports os


### PR DESCRIPTION
Add AgentDependencies which is a requirement with the newest versions of awslogs agent

Addresses issue #9 